### PR TITLE
Add a parameter in the broker config to enbale/ disable row level sec…

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -85,6 +85,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   protected final Set<String> _trackedHeaders;
   protected final BrokerRequestIdGenerator _requestIdGenerator;
   protected final long _brokerTimeoutMs;
+  protected final boolean _enableRowColumnLevelAuth;
   protected final QueryLogger _queryLogger;
   @Nullable
   protected final String _enableNullHandling;
@@ -110,6 +111,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     _trackedHeaders = BrokerQueryEventListenerFactory.getTrackedHeaders();
     _requestIdGenerator = new BrokerRequestIdGenerator(brokerId);
     _brokerTimeoutMs = config.getProperty(Broker.CONFIG_OF_BROKER_TIMEOUT_MS, Broker.DEFAULT_BROKER_TIMEOUT_MS);
+    _enableRowColumnLevelAuth = config.getProperty(Broker.CONFIG_OF_BROKER_ENABLE_ROW_COLUMN_LEVEL_AUTH,
+        Broker.DEFAULT_BROKER_ENABLE_ROW_COLUMN_LEVEL_AUTH);
     _queryLogger = new QueryLogger(config);
     _enableNullHandling = config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING);
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -344,15 +344,17 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       if (!tableAuthorizationResult.hasAccess()) {
         throwTableAccessError(tableAuthorizationResult);
       }
-      AccessControl accessControl = _accessControlFactory.create();
-      for (String tableName : tables) {
-        accessControl.getRowColFilters(requesterIdentity, tableName).getRLSFilters()
-            .ifPresent(rowFilters -> {
-              String combinedFilters =
-                  rowFilters.stream().map(filter -> "( " + filter + " )").collect(Collectors.joining(" AND "));
-              String key = RlsUtils.buildRlsFilterKey(tableName);
-              compiledQuery.getOptions().put(key, combinedFilters);
-            });
+      if (_enableRowColumnLevelAuth) {
+        AccessControl accessControl = _accessControlFactory.create();
+        for (String tableName : tables) {
+          accessControl.getRowColFilters(requesterIdentity, tableName).getRLSFilters()
+              .ifPresent(rowFilters -> {
+                String combinedFilters =
+                    rowFilters.stream().map(filter -> "( " + filter + " )").collect(Collectors.joining(" AND "));
+                String key = RlsUtils.buildRlsFilterKey(tableName);
+                compiledQuery.getOptions().put(key, combinedFilters);
+              });
+        }
       }
     }
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityIntegrationTest.java
@@ -71,6 +71,7 @@ public class RowLevelSecurityIntegrationTest extends BaseClusterIntegrationTest 
 
   @Override
   protected void overrideBrokerConf(PinotConfiguration brokerConf) {
+    brokerConf.setProperty("pinot.broker.enable.row.column.level.auth", "true");
     brokerConf.setProperty("pinot.broker.access.control.class",
         "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
     brokerConf.setProperty("pinot.broker.access.control.principals", "admin, user, user2");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -341,6 +341,9 @@ public class CommonConstants {
     public static final double DEFAULT_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND = 10_000d;
     public static final String CONFIG_OF_BROKER_TIMEOUT_MS = "pinot.broker.timeoutMs";
     public static final long DEFAULT_BROKER_TIMEOUT_MS = 10_000L;
+    public static final String CONFIG_OF_BROKER_ENABLE_ROW_COLUMN_LEVEL_AUTH =
+        "pinot.broker.enable.row.column.level.auth";
+    public static final boolean DEFAULT_BROKER_ENABLE_ROW_COLUMN_LEVEL_AUTH = false;
     public static final String CONFIG_OF_BROKER_ID = "pinot.broker.instance.id";
     public static final String CONFIG_OF_BROKER_INSTANCE_TAGS = "pinot.broker.instance.tags";
     public static final String CONFIG_OF_BROKER_HOSTNAME = "pinot.broker.hostname";


### PR DESCRIPTION
Introduces a new configuration option in the broker settings to control whether row-level security features are enabled or disabled.


## Parameter added
`pinot.broker.enable.row.column.level.auth` 

## Default value
'false' i.e. rol/ column level auth is disabled by default

## Scope
It applies to both single and multi stage queries. 

